### PR TITLE
Added get_current_revisions() to handle branching migrations

### DIFF
--- a/alembicverify/util.py
+++ b/alembicverify/util.py
@@ -39,7 +39,15 @@ def get_head_revision(config, engine, script):
     return _get_revision(config, engine, script, revision_type='head')
 
 
-def _get_revision(config, engine, script, revision_type='current'):
+def get_current_revisions(config, engine, script):
+    """Inspection helper. Safe for use in migration histories with branching migrations.
+
+    :returns A list of revision hashes. The list will be length 1 if there are no branches at the current revision.
+    """
+    return _get_revision(config, engine, script, handle_branching_migrations=True)
+
+
+def _get_revision(config, engine, script, revision_type='current', handle_branching_migrations=False):
     with engine.connect() as conn:
         with EnvironmentContext(config, script) as env_context:
             env_context.configure(conn, version_table="alembic_version")
@@ -47,5 +55,13 @@ def _get_revision(config, engine, script, revision_type='current'):
                 revision = env_context.get_head_revision()
             else:
                 migration_context = env_context.get_context()
-                revision = migration_context.get_current_revision()
+                if handle_branching_migrations:
+                    revision = migration_context.get_current_heads()
+                    has_multiple_heads = type(revision) != str
+                    if not has_multiple_heads:
+                        revision = [revision]
+                else:
+                    # handle_branching_migrations=False, so use the "old" alembic code path
+                    revision = migration_context.get_current_revision()
+
     return revision

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -5,6 +5,7 @@ from mock import MagicMock, Mock, patch, call
 from alembicverify.util import (
     _get_revision,
     get_current_revision,
+    get_current_revisions,
     get_head_revision,
     make_alembic_config,
     prepare_schema_from_migrations,
@@ -102,6 +103,15 @@ def test_get_current_revision(_get_revision_mock):
 
     assert _get_revision_mock.return_value == result
     _get_revision_mock.assert_called_once_with(config, engine, script)
+
+
+def test_get_current_revisions(_get_revision_mock):
+    config, engine, script = Mock(), Mock(), Mock()
+
+    result = get_current_revisions(config, engine, script)
+
+    assert _get_revision_mock.return_value == result
+    _get_revision_mock.assert_called_once_with(config, engine, script, handle_branching_migrations=False)
 
 
 def test_get_head_revision(_get_revision_mock):


### PR DESCRIPTION
I'm working in a repo that uses alembic's [branching migrations](https://alembic.sqlalchemy.org/en/latest/branches.html) feature. Because of the branches, `get_current_revision()` throws an error while backtracking through migrations. The new `get_current_revisions()` method is safe to use in branching repos.

For reference, here's the test I'm using it in, which is a modified version of the base test from the docs:

```python
@pytest.mark.usefixtures("new_db_left")
def test_upgrades_and_downgrades(uri_left, alembic_config_left):
    """Starting with an empty database, run all upgrades and then downgrades.

    This allows us to verify that all migrations are sequential, and that no
    migration throws an exception.

    Modified from https://alembic-verify.readthedocs.io/en/latest/
    """

    engine, script = prepare_schema_from_migrations(uri_left, alembic_config_left)
    next_revisions = get_head_revision(alembic_config_left, engine, script)

    while next_revisions:
        command.downgrade(alembic_config_left, '-1')
        next_revisions = get_current_revisions(alembic_config_left, engine, script)

        for revision in next_revisions:
            command.downgrade(alembic_config_left, revision)
```

I didn't add the test to the docs because it only follows branches 1 level down, and I didn't want that to be a gotcha for future developers. Maybe a flawed example is better than nothing though?