### PR TITLE
Removed unused pytest import in _factories.py

### DIFF
--- a/src/alembicverify/_factories.py
+++ b/src/alembicverify/_factories.py
@@ -3,7 +3,6 @@ from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from typing import Any
 
-import pytest
 from alembic.config import Config
 from sqlalchemy_utils import create_database, drop_database
 


### PR DESCRIPTION
This import causes failues in production envoirements where pytest is not installed.